### PR TITLE
fix: missing package github.com/rokett/citrix-netscaler-exporter/nets…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir Citrix-NetScaler-Exporter
 COPY . Citrix-NetScaler-Exporter
 WORKDIR /go/src/Citrix-NetScaler-Exporter
 RUN go get github.com/alecthomas/kingpin
+RUN go get github.com/rokett/citrix-netscaler-exporter/netscaler
 RUN go build .
 RUN cp /go/src/Citrix-NetScaler-Exporter/Citrix-NetScaler-Exporter /
 ENTRYPOINT ["/Citrix-NetScaler-Exporter"]


### PR DESCRIPTION
…caler during build

Hi,

ty for creating netscaler exporter.

Small problem with docker build. When building image with Dockerfile it would fail with:
`main.go:11:2: cannot find package "github.com/rokett/citrix-netscaler-exporter/netscaler" in any of:
        /go/src/Citrix-NetScaler-Exporter/vendor/github.com/rokett/citrix-netscaler-exporter/netscaler (vendor tree)
        /usr/local/go/src/github.com/rokett/citrix-netscaler-exporter/netscaler (from $GOROOT)
        /go/src/github.com/rokett/citrix-netscaler-exporter/netscaler (from $GOPATH)
The command '/bin/sh -c go build .' returned a non-zero code: 1`

Fetching missing package with `go get` in Dockerfile fixed build issue, hence this PR. 

