### PR TITLE
Fixed issue retrieving servicegroup stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.3.1] - 2020-07-02
 ### Fixed
- - Error when trying to retrieve stats for servicegroups which have multiple members, where each member is the same server but on different ports.  We now include the port as a label to avoid duplicates.
+ - #13 Error when trying to retrieve stats for servicegroups which have multiple members, where each member is the same server but on different ports.  We now include the port as a label to avoid duplicates.
 
 ## [4.3.0] - 2020-01-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2020-07-02
+### Fixed
+ - Error when trying to retrieve stats for servicegroups which have multiple members, where each member is the same server but on different ports.  We now include the port as a label to avoid duplicates.
+
 ## [4.3.0] - 2020-01-24
 ### Added
  - VPN Virtual Server (NetScaler Gateway) stats.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine as builder
 
-ENV VERSION="4.3.0"
+ENV VERSION="4.3.1"
 
 WORKDIR $GOPATH/src/github.com/rokett
 RUN \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 APP = Citrix-NetScaler-Exporter
-VERSION = 4.3.0
+VERSION = 4.3.1
 BINARY-LINUX = ${APP}_${VERSION}_Linux_amd64
 
 BUILD_VER = $(shell git rev-parse HEAD)

--- a/collector/service_groups.go
+++ b/collector/service_groups.go
@@ -17,6 +17,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -29,6 +30,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -41,6 +43,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -53,6 +56,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -65,6 +69,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -77,6 +82,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -89,6 +95,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -101,6 +108,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -113,6 +121,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -125,6 +134,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -137,6 +147,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 
@@ -149,6 +160,7 @@ var (
 			"ns_instance",
 			"servicegroup",
 			"member",
+			"port",
 		},
 	)
 )
@@ -162,82 +174,106 @@ func (e *Exporter) collectServiceGroupsState(sg netscaler.ServiceGroupMemberStat
 		state = 1.0
 	}
 
-	e.serviceGroupsState.WithLabelValues(e.nsInstance, sgName, servername).Set(state)
+	port := strconv.Itoa(sg.PrimaryPort)
+
+	e.serviceGroupsState.WithLabelValues(e.nsInstance, sgName, servername, port).Set(state)
 }
 
 func (e *Exporter) collectServiceGroupsAvgTTFB(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsAvgTTFB.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.AvgTimeToFirstByte, 64)
-	e.serviceGroupsAvgTTFB.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsAvgTTFB.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsTotalRequests(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsTotalRequests.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.TotalRequests, 64)
-	e.serviceGroupsTotalRequests.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsTotalRequests.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsTotalResponses(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsTotalResponses.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.TotalResponses, 64)
-	e.serviceGroupsTotalResponses.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsTotalResponses.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsTotalRequestBytes(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsTotalRequestBytes.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.TotalRequestBytes, 64)
-	e.serviceGroupsTotalRequestBytes.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsTotalRequestBytes.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsTotalResponseBytes(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsTotalResponseBytes.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.TotalResponseBytes, 64)
-	e.serviceGroupsTotalResponseBytes.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsTotalResponseBytes.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsCurrentClientConnections(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsCurrentClientConnections.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.CurrentClientConnections, 64)
-	e.serviceGroupsCurrentClientConnections.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsCurrentClientConnections.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsSurgeCount(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsSurgeCount.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.SurgeCount, 64)
-	e.serviceGroupsSurgeCount.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsSurgeCount.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsCurrentServerConnections(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsCurrentServerConnections.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.CurrentServerConnections, 64)
-	e.serviceGroupsCurrentServerConnections.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsCurrentServerConnections.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsServerEstablishedConnections(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsServerEstablishedConnections.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.ServerEstablishedConnections, 64)
-	e.serviceGroupsServerEstablishedConnections.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsServerEstablishedConnections.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsCurrentReusePool(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsCurrentReusePool.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.CurrentReusePool, 64)
-	e.serviceGroupsCurrentReusePool.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsCurrentReusePool.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }
 
 func (e *Exporter) collectServiceGroupsMaxClients(sg netscaler.ServiceGroupMemberStats, sgName string, servername string) {
 	e.serviceGroupsMaxClients.Reset()
 
+	port := strconv.Itoa(sg.PrimaryPort)
+
 	val, _ := strconv.ParseFloat(sg.MaxClients, 64)
-	e.serviceGroupsMaxClients.WithLabelValues(e.nsInstance, sgName, servername).Set(val)
+	e.serviceGroupsMaxClients.WithLabelValues(e.nsInstance, sgName, servername, port).Set(val)
 }

--- a/make.bat
+++ b/make.bat
@@ -2,7 +2,7 @@
 SETLOCAL
 
 set APP=Citrix-NetScaler-Exporter
-set VERSION=4.3.0
+set VERSION=4.3.1
 set BINARY-WINDOWS-X64=%APP%_%VERSION%_Windows_amd64.exe
 set BINARY-LINUX=%APP%_%VERSION%_Linux_amd64
 

--- a/netscaler/get_ns_stats.go
+++ b/netscaler/get_ns_stats.go
@@ -14,10 +14,10 @@ type NSStats struct {
 	PktCPUUsagePcnt                        float64 `json:"pktcpuusagepcnt"`
 	FlashPartitionUsage                    float64 `json:"disk0perusage"`
 	VarPartitionUsage                      float64 `json:"disk1perusage"`
-	TotalReceivedMB	string	`json:"totrxmbits"`
-	TotalTransmitMB string `json:"tottxmbits"`
-	HTTPRequests                       string `json:"httptotrequests"`
-	HTTPResponses                      string `json:"httptotresponses"`
+	TotalReceivedMB                        string  `json:"totrxmbits"`
+	TotalTransmitMB                        string  `json:"tottxmbits"`
+	HTTPRequests                           string  `json:"httptotrequests"`
+	HTTPResponses                          string  `json:"httptotresponses"`
 	TCPCurrentClientConnections            string  `json:"tcpcurclientconn"`
 	TCPCurrentClientConnectionsEstablished string  `json:"tcpcurclientconnestablished"`
 	TCPCurrentServerConnections            string  `json:"tcpcurserverconn"`

--- a/netscaler/get_service_group_member_stats.go
+++ b/netscaler/get_service_group_member_stats.go
@@ -9,6 +9,7 @@ import (
 
 // ServiceGroupMemberStats represents the data returned from the /stat/servicegroupmember Nitro API endpoint
 type ServiceGroupMemberStats struct {
+	PrimaryPort                  int    `json:"primaryport"`
 	State                        string `json:"state"`
 	AvgTimeToFirstByte           string `json:"avgsvrttfb"`
 	TotalRequests                string `json:"totalrequests"`


### PR DESCRIPTION
Fixes problem where a service group with multiple members, where each member is the same service but uses a different port, errors because of duplicate labels.

Adding the member port ensures uniqueness.