### PR TITLE
Import fixes

### DIFF
--- a/collector/aaa.go
+++ b/collector/aaa.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -3,9 +3,7 @@ package collector
 import (
 	"strconv"
 	"strings"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/collector/cs_virtual_servers.go
+++ b/collector/cs_virtual_servers.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/gslb_services.go
+++ b/collector/gslb_services.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/gslb_virtual_servers.go
+++ b/collector/gslb_virtual_servers.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/interfaces.go
+++ b/collector/interfaces.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/service_groups.go
+++ b/collector/service_groups.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/services.go
+++ b/collector/services.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/virtual_servers.go
+++ b/collector/virtual_servers.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/vpn_virtual_servers.go
+++ b/collector/vpn_virtual_servers.go
@@ -2,9 +2,7 @@ package collector
 
 import (
 	"strconv"
-
-	"citrix-netscaler-exporter/netscaler"
-
+	"github.com/encoretechnologies/citrix-netscaler-exporter/netscaler"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module citrix-netscaler-exporter
+module github.com/encoretechnologies/citrix-netscaler-exporter
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/EncoreTechnologies/citrix-netscaler-exporter/collector"
+	"github.com/encoretechnologies/citrix-netscaler-exporter/collector"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -7,14 +7,11 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-
-	"citrix-netscaler-exporter/collector"
+	"github.com/EncoreTechnologies/citrix-netscaler-exporter/collector"
 )
 
 var (

--- a/netscaler/connect.go
+++ b/netscaler/connect.go
@@ -3,9 +3,8 @@ package netscaler
 import (
 	"bytes"
 	"encoding/json"
-	"io"
+	"io/ioutil"
 	"net/http"
-
 	"github.com/pkg/errors"
 )
 
@@ -55,7 +54,7 @@ func Connect(c *NitroClient) error {
 	case 201:
 		var response = new(NSAPIResponse)
 
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		err = json.Unmarshal(body, &response)
 		if err != nil {
@@ -64,7 +63,7 @@ func Connect(c *NitroClient) error {
 
 		return nil
 	default:
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		return errors.New("read failed: " + resp.Status + " (" + string(body) + ")")
 	}

--- a/netscaler/disconnect.go
+++ b/netscaler/disconnect.go
@@ -3,7 +3,7 @@ package netscaler
 import (
 	"bytes"
 	"encoding/json"
-	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -48,7 +48,7 @@ func Disconnect(c *NitroClient) error {
 	case 201:
 		return nil
 	default:
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		return errors.New("Logout failed: " + resp.Status + " (" + string(body) + ")")
 	}

--- a/netscaler/get_config.go
+++ b/netscaler/get_config.go
@@ -1,7 +1,7 @@
 package netscaler
 
 import (
-	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -32,11 +32,11 @@ func (c *NitroClient) GetConfig(configType string, querystring string) ([]byte, 
 
 	switch resp.StatusCode {
 	case 200:
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		return body, nil
 	default:
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		return body, errors.New("read failed: " + resp.Status + " (" + string(body) + ")")
 	}

--- a/netscaler/get_stats.go
+++ b/netscaler/get_stats.go
@@ -1,7 +1,7 @@
 package netscaler
 
 import (
-	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -32,11 +32,11 @@ func (c *NitroClient) GetStats(statsType string, querystring string) ([]byte, er
 
 	switch resp.StatusCode {
 	case 200:
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		return body, nil
 	default:
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := ioutil.ReadAll(resp.Body)
 
 		return body, errors.New("read failed: " + resp.Status + " (" + string(body) + ")")
 	}


### PR DESCRIPTION
Working on RHEL7

```
go version go1.15.5 linux/amd64
```

```
go get github.com/encoretechnologies/citrix-netscaler-exporter@4.5.2
go: downloading github.com/encoretechnologies/citrix-netscaler-exporter v0.0.0-20210308195925-366a692acb24
go: github.com/encoretechnologies/citrix-netscaler-exporter 4.5.2 => v0.0.0-20210308195925-366a692acb24
go: downloading github.com/prometheus/client_golang v0.8.0
go: downloading github.com/go-kit/kit v0.6.0
go: downloading github.com/pkg/errors v0.8.0
go: downloading github.com/prometheus/common v0.0.0-20171006141418-1bab55dd05db
go: downloading github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612
go: downloading github.com/prometheus/procfs v0.0.0-20170703101242-e645f4e5aaa8
go: downloading github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05
go: downloading github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.0
go: downloading github.com/go-logfmt/logfmt v0.3.0
go: downloading github.com/go-stack/stack v1.6.0
go: downloading github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
```